### PR TITLE
Change lanes.c to export it's functions properly.

### DIFF
--- a/src/lanes.lua
+++ b/src/lanes.lua
@@ -41,10 +41,9 @@ THE SOFTWARE.
 
 module( "lanes", package.seeall )
 
-require "lua51-lanes"
-assert( type(lanes)=="table" )
+local mm = require "lua51-lanes"
+assert( type(mm)=="table" )
 
-local mm= lanes
 
 local linda_id=    assert( mm.linda_id )
 


### PR DESCRIPTION
Right now, lanes.c writes it's exported functions directly to the globals table. This is unacceptable IMO, especially since most of the functions in lanes.c aren't even intended to be accessed by the end user. So not only does lanes.c potentially overwrite the user's variables, it also exposes functions that shouldn't even be visible.

This change makes lanes.c export it's functions in a table, which is only used by the lanes.lua module and keeps them from being accessible to the rest of the program.

Here is an example of what happens with the current version ( the version before applying this change ). Notice how some of the private lua51-lanes functions are written directly to the globals table and are accessible to all:
    linda_id = "Example"
    local linda_id_ref = linda_id
    assert(linda_id == linda_id_ref)
    local lanes = require('lanes')
    assert(linda_id ~= linda_id_ref)
    linda_id() -- This causes a seg fault! It shouldn't even be present outside the lanes module.

Note: This change is part of the 5.2-compat branch, but is backwards compatible previous versions of Lanes and Lua 5.1

Edit: Clarify what "current version" means.
