### PR TITLE
Fixed compilation warning

### DIFF
--- a/src/lanes.c
+++ b/src/lanes.c
@@ -1588,7 +1588,7 @@ static bool_t thread_cancel( struct s_lane *s, double secs, bool_t force )
 //                   / "error"     finished at an error, error value is there
 //                   / "cancelled"   execution cancelled by M (state gone)
 //
-static char const * const thread_status_string( struct s_lane *s)
+static char const * thread_status_string( struct s_lane *s)
 {
 	enum e_status st = s->status;    // read just once (volatile)
 	char const * str;


### PR DESCRIPTION
Just a small fix necessary because -Werror is used and GCC 4.2 on OS X complains.
