### PR TITLE
keeper.c: include stdint.h for uintptr_t typedef

### DIFF
--- a/src/keeper.c
+++ b/src/keeper.c
@@ -40,6 +40,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <ctype.h>
 


### PR DESCRIPTION
Corrects this build error:

```
gcc -Wall -Werror -O2 -I/usr/include/lua5.1  -D_GNU_SOURCE -fPIC   -c -o keeper.o keeper.c
keeper.c: In function ‘keeper_acquire’:
keeper.c:626:21: error: ‘uintptr_t’ undeclared (first use in this function)
   unsigned int i= ((uintptr_t)(ptr) >> 3) % GNbKeepers;
                     ^
keeper.c:626:21: note: each undeclared identifier is reported only once for each function it appears in
<builtin>: recipe for target 'keeper.o' failed
make[1]: *** [keeper.o] Error 1
```

Signed-off-by: Steven Noonan steven@uplinklabs.net
