### PR TITLE
Update tools.c

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -42,7 +42,9 @@ THE SOFTWARE.
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
+#if !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 /*
  * ###############################################################################################


### PR DESCRIPTION
Actually, you shouldn't need malloc.h at all, it's obsolete; including stdlib.h should take care of what malloc.h used to handle.

I can't compile lanes on OS X 10.9.1 without this patch.
