### PR TITLE
Fix segfault in LG_lane_new

### DIFF
--- a/src/lanes.c
+++ b/src/lanes.c
@@ -2419,13 +2419,13 @@ LUAG_FUNC( lane_new)
 		lua_sethook( L2, cancel_hook, LUA_MASKCOUNT, cancelstep_idx);
 	}
 
+	STACK_END( L, 1);
+	STACK_END( L2, 1 + nargs);
+
 	DEBUGSPEW_CODE( fprintf( stderr, INDENT_BEGIN "lane_new: launching thread\n" INDENT_END));
 	THREAD_CREATE( &s->thread, lane_main, s, priority);
 
 	DEBUGSPEW_CODE( -- U->debugspew_indent_depth);
-
-	STACK_END( L, 1);
-	STACK_END( L2, 1 + nargs);
 	return 1;
 }
 


### PR DESCRIPTION
This should fix a rare segfault on creating a lane (in particular, `require "lanes".configure()` could crash because a lane for timers is created by default). The issue is that after a thread for a lane was created, parent thread checked the size of its Lua stack. If the child managed to start initializing, that could lead to parent thread calling lua_error on child state while it was in another Lua C API function, causing a segfault.

I have observed the crashes on Lua 5.3 using `demote_full_userdata = true` option for `lanes.configure` as per #111. I can reproduce it once in about 1000-5000 runs of `require "lanes".configure({demote_full_userdata = true})`. After applying this patch I still get segfaults but much rarer, once per 15000-25000 runs, so I believe I actually fixed a bug and these rarer segaults are a different issue.