### PR TITLE
Fix crash on lanes.configure() on Lua 5.3

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -1256,13 +1256,13 @@ static void inter_copy_func( struct s_Universe* U, lua_State* L2, uint_t L2_cach
 
 		/* push over any upvalues; references to this function will come from
 		* cache so we don't end up in eternal loop.
-		* Lua5.2: one of the upvalues is _ENV, which we don't want to copy!
+		* Lua5.2 and Lua5.3: one of the upvalues is _ENV, which we don't want to copy!
 		* instead, the function shall have LUA_RIDX_GLOBALS taken in the destination state!
 		*/
 		{
 			char const* upname;
-#if LUA_VERSION_NUM == 502
-			// With Lua 5.2, each Lua function gets its environment as one of its upvalues (named LUA_ENV, aka "_ENV" by default)
+#if LUA_VERSION_NUM >= 502
+			// Starting with Lua 5.2, each Lua function gets its environment as one of its upvalues (named LUA_ENV, aka "_ENV" by default)
 			// Generally this is LUA_RIDX_GLOBALS, which we don't want to copy from the source to the destination state...
 			// -> if we encounter an upvalue equal to the global table in the source, bind it to the destination's global table
 			lua_pushglobaltable( L);                           // ... _G
@@ -1270,7 +1270,7 @@ static void inter_copy_func( struct s_Universe* U, lua_State* L2, uint_t L2_cach
 			for( n = 0; (upname = lua_getupvalue( L, i, 1 + n)) != NULL; ++ n)
 			{                                                  // ... _G up[n]
 				DEBUGSPEW_CODE( fprintf( stderr, INDENT_BEGIN "UPNAME[%d]: %s -> " INDENT_END, n, upname));
-#if LUA_VERSION_NUM == 502
+#if LUA_VERSION_NUM >= 502
 				if( lua_rawequal( L, -1, -2)) // is the upvalue equal to the global table?
 				{
 					DEBUGSPEW_CODE( fprintf( stderr, "pushing destination global scope\n"));
@@ -1287,7 +1287,7 @@ static void inter_copy_func( struct s_Universe* U, lua_State* L2, uint_t L2_cach
 				}
 				lua_pop( L, 1);                                  // ... _G
 			}
-#if LUA_VERSION_NUM == 502
+#if LUA_VERSION_NUM >= 502
 			lua_pop( L, 1);                                    // ...
 #endif // LUA_VERSION_NUM
 		}


### PR DESCRIPTION
Logic for detecting _ENV upvalue was only used for Lua 5.2 but not for Lua 5.3. After fixing this #111 seems to go away.