### PR TITLE
Fix standard library lists for Lua 5.3

### DIFF
--- a/src/lanes.lua
+++ b/src/lanes.lua
@@ -216,6 +216,7 @@ local valid_libs =
 	["math"] = true,
 	["debug"] = true,
 	["bit32"] = true, -- Lua 5.2 only, ignored silently under 5.1
+	["utf8"] = true, -- Lua 5.3 only, ignored silently under 5.1 and 5.2
 	--
 	["base"] = true,
 	["coroutine"] = true, -- part of "base" in Lua 5.1

--- a/src/tools.c
+++ b/src/tools.c
@@ -194,8 +194,13 @@ static const luaL_Reg libs[] =
 	{ LUA_OSLIBNAME, luaopen_os},
 	{ LUA_IOLIBNAME, luaopen_io},
 #endif // PLATFORM_XBOX
+#if LUA_VERSION_NUM >= 503
+	{ LUA_UTF8LIBNAME, luaopen_utf8},
+#endif
 #if LUA_VERSION_NUM >= 502
+#ifdef luaopen_bit32
 	{ LUA_BITLIBNAME, luaopen_bit32},
+#endif
 	{ LUA_COLIBNAME, luaopen_coroutine}, // Lua 5.2: coroutine is no longer a part of base!
 #else // LUA_VERSION_NUM
 	{ LUA_COLIBNAME, NULL},              // Lua 5.1: part of base package


### PR DESCRIPTION
Fixes crash on require under Lua 5.3 without LUA_COMPAT_5_2 (don't load bitlib if it's not present).
Fixes utf8 library not loaded under Lua 5.3.