### PR TITLE
add USE_PTHREAD to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ FIND_PROGRAM(LUA NAMES lua5.1 lua51 lua)
 FIND_PROGRAM(LUAC NAMES luac5.1 luac51 luac)
 INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR})
 
+if(USE_PTHREAD)
+ADD_DEFINITIONS(-DHAVE_WIN32_PTHREAD)
+endif(USE_PTHREAD)
 #2DO - patch threading.c to suppot cygwin.
 # The following values are just a guess.
 # WARNING: test segfault under Cygwin


### PR DESCRIPTION
We did not have an CMake option for setting HAVE_WIN32_PTHREAD on win32