### PR TITLE
'Linking error while embedding Lanes' on Linux fix

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -34,10 +34,8 @@ THE SOFTWARE.
 
 ===============================================================================
 */
-#include "platform.h"
-#if defined(PLATFORM_LINUX)
-# define _GNU_SOURCE /* must be defined before <sched.h> */
-# include <sched.h>
+#if defined(__linux__)
+# define _GNU_SOURCE /* must be defined before any include */
 #endif
 
 #include <stdio.h>

--- a/src/threading.c
+++ b/src/threading.c
@@ -34,6 +34,12 @@ THE SOFTWARE.
 
 ===============================================================================
 */
+#include "platform.h"
+#if defined(PLATFORM_LINUX)
+# define _GNU_SOURCE /* must be defined before <sched.h> */
+# include <sched.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>


### PR DESCRIPTION

**This PR fixes this linking errors (when Lanes is embedded)**:
undefined reference to CPU_ZERO
undefined reference to CPU_SET
