### PR TITLE
Threads compilation for Android fixed; Thread can't be killed to date…

### DIFF
--- a/src/threading.h
+++ b/src/threading.h
@@ -143,7 +143,7 @@ enum e_status { PENDING, RUNNING, WAITING, DONE, ERROR_ST, CANCELLED };
   //
   #if defined( PLATFORM_OSX)
     #define YIELD() pthread_yield_np()
-  #elif defined( PLATFORM_WIN32) || defined( PLATFORM_POCKETPC) // no PTHREAD for PLATFORM_XBOX
+#elif defined( PLATFORM_WIN32) || defined( PLATFORM_POCKETPC) || defined(__ANDROID__) // no PTHREAD for PLATFORM_XBOX
     // for some reason win32-pthread doesn't have pthread_yield(), but sched_yield()
     #define YIELD() sched_yield()
   #else


### PR DESCRIPTION
… (warning in logcat).

Closes an #156 issue

PS
Compiled on NDK 17b

Just for NOTE:
https://github.com/android-ndk/ndk/issues/716
