### PR TITLE
NetBSD support

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -891,9 +891,16 @@ void THREAD_SET_PRIORITY( int prio)
 
 void THREAD_SET_AFFINITY( unsigned int aff)
 {
-	cpu_set_t cpuset;
 	int bit = 0;
+#ifdef __NetBSD__
+	cpuset_t *cpuset = cpuset_create();
+	if( cpuset == NULL)
+		_PT_FAIL( errno, "cpuset_create", __FILE__, __LINE__-2 );
+#define CPU_SET(b, s) cpuset_set(b, *(s))
+#else
+	cpu_set_t cpuset;
 	CPU_ZERO( &cpuset);
+#endif
 	while( aff != 0)
 	{
 		if( aff & 1)
@@ -905,6 +912,9 @@ void THREAD_SET_AFFINITY( unsigned int aff)
 	}
 #ifdef __ANDROID__
 	PT_CALL( sched_setaffinity( pthread_self(), sizeof(cpu_set_t), &cpuset));
+#elif defined(__NetBSD__)
+	PT_CALL( pthread_setaffinity_np( pthread_self(), cpuset_size(cpuset), cpuset));
+	cpuset_destroy( cpuset);
 #else
 	PT_CALL( pthread_setaffinity_np( pthread_self(), sizeof(cpu_set_t), &cpuset));
 #endif
@@ -1001,8 +1011,10 @@ bool_t THREAD_WAIT( THREAD_T *ref, double secs , SIGNAL_T *signal_ref, MUTEX_T *
 	{
 		// exact API to set the thread name is platform-dependant
 		// if you need to fix the build, or if you know how to fill a hole, tell me (bnt.germain@gmail.com) so that I can submit the fix in github.
-#if defined PLATFORM_BSD
+#if defined PLATFORM_BSD && !defined __NetBSD__
 		pthread_set_name_np( pthread_self(), _name);
+#elif defined PLATFORM_BSD && defined __NetBSD__
+		pthread_setname_np( pthread_self(), "%s", (void *)_name);
 #elif defined PLATFORM_LINUX
 	#if LINUX_USE_PTHREAD_SETNAME_NP
 		pthread_setname_np( pthread_self(), _name);

--- a/src/threading.h
+++ b/src/threading.h
@@ -143,7 +143,7 @@ enum e_status { PENDING, RUNNING, WAITING, DONE, ERROR_ST, CANCELLED };
   //
   #if defined( PLATFORM_OSX)
     #define YIELD() pthread_yield_np()
-#elif defined( PLATFORM_WIN32) || defined( PLATFORM_POCKETPC) || defined(__ANDROID__) // no PTHREAD for PLATFORM_XBOX
+#elif defined( PLATFORM_WIN32) || defined( PLATFORM_POCKETPC) || defined(__ANDROID__) || defined(__NetBSD__) // no PTHREAD for PLATFORM_XBOX
     // for some reason win32-pthread doesn't have pthread_yield(), but sched_yield()
     #define YIELD() sched_yield()
   #else


### PR DESCRIPTION
This adds support for NetBSD's flavour of pthreads. There are minor differences in the declaration of the non-portable pthread functions, and `sched_yield` is provided instead of `pthread_yield_np`.

This allows LuaLanes to build and the test suite to run on NetBSD.