### PR TITLE
Replace deprecated pthread_yield with sched_yield

### DIFF
--- a/src/threading.h
+++ b/src/threading.h
@@ -147,7 +147,7 @@ enum e_status { PENDING, RUNNING, WAITING, DONE, ERROR_ST, CANCELLED };
     // for some reason win32-pthread doesn't have pthread_yield(), but sched_yield()
     #define YIELD() sched_yield()
   #else
-    #define YIELD() pthread_yield()
+    #define YIELD() sched_yield()
   #endif
 	#define THREAD_CALLCONV
 #endif //THREADAPI == THREADAPI_PTHREAD


### PR DESCRIPTION
Since glibc 2.34, pthread_yield is nonstandard and marked as deprecated. See: https://man7.org/linux/man-pages/man3/pthread_yield.3.html