### PR TITLE
Update lanes-3.16.0-0.rockspec

### DIFF
--- a/lanes-3.16.0-0.rockspec
+++ b/lanes-3.16.0-0.rockspec
@@ -10,7 +10,7 @@ package = "Lanes"
 version = "3.16.0-0"
 
 source= {
-	url= "https://github.com/LuaLanes/lanes.git",
+	url= "git+https://github.com/LuaLanes/lanes.git",
 	branch= "v3.16.0"
 }
 


### PR DESCRIPTION
does not install from the rockspec without using git for url format