### PR TITLE
Fix STACK_GROW under Clang

### DIFF
--- a/src/macros_and_utils.h
+++ b/src/macros_and_utils.h
@@ -82,7 +82,7 @@ extern char const* debugspew_indent;
 
 #define ASSERT_L(c) _ASSERT_L(L,c)
 
-inline void STACK_GROW(lua_State * L, int n_)
+static inline void STACK_GROW(lua_State * L, int n_)
 {
     if (!lua_checkstack(L, n_))
         luaL_error(L, "Cannot grow stack!");


### PR DESCRIPTION
Before this fix:
```
$ make CC=clang
[…]
$ make test
make atexit
make[1]: Entering directory '/home/karol/lanes'
LUA_CPATH="./src/?.so" LUA_PATH="./src/?.lua;./tests/?.lua" lua tests/atexit.lua
lua: error loading module 'lanes.core' from file './src/lanes/core.so':
	./src/lanes/core.so: undefined symbol: STACK_GROW
stack traceback:
	[C]: in ?
	[C]: in function 'require'
	./src/lanes.lua:38: in main chunk
	[C]: in function 'require'
	tests/atexit.lua:1: in main chunk
	[C]: in ?
make[1]: *** [Makefile:172: atexit] Error 1
make[1]: Leaving directory '/home/karol/lanes'
make: *** [Makefile:75: test] Error 2
```
This is a [known peculiarity of Clang](https://github.com/llvm/llvm-project/issues/55274). Support for Clang is important to me due to the fact that it's Zig's backend for C and in the Zig world all projects try to build any and all C dependencies using Zig's build system only, without the use of external scripts or Makefiles.